### PR TITLE
exporting dll symbols for windows

### DIFF
--- a/src/native/QtNetCoreQml/QtNetCoreQml.h
+++ b/src/native/QtNetCoreQml/QtNetCoreQml.h
@@ -3,18 +3,6 @@
 
 #include <QtCore/qglobal.h>
 
-enum NetVariantTypeEnum {
-    NetVariantTypeEnum_Invalid = 0,
-    NetVariantTypeEnum_Bool = 1,
-    NetVariantTypeEnum_Char = 2,
-    NetVariantTypeEnum_Int = 3,
-    NetVariantTypeEnum_UInt = 4,
-    NetVariantTypeEnum_Double = 5,
-    NetVariantTypeEnum_String = 6,
-    NetVariantTypeEnum_DateTime = 7,
-    NetVariantTypeEnum_Object = 8
-};
-
 #define NetGCHandle void
 
 #if _MSC_VER
@@ -58,5 +46,18 @@ enum NetVariantTypeEnum {
         typedef LPCSTR LPTCSTR;
     #endif
 #endif
+
+enum Q_DECL_EXPORT NetVariantTypeEnum {
+    NetVariantTypeEnum_Invalid = 0,
+    NetVariantTypeEnum_Bool = 1,
+    NetVariantTypeEnum_Char = 2,
+    NetVariantTypeEnum_Int = 3,
+    NetVariantTypeEnum_UInt = 4,
+    NetVariantTypeEnum_Double = 5,
+    NetVariantTypeEnum_String = 6,
+    NetVariantTypeEnum_DateTime = 7,
+    NetVariantTypeEnum_Object = 8
+};
+
 
 #endif // QTNETCOREQML_GLOBAL_H

--- a/src/native/QtNetCoreQml/QtNetCoreQml/qml/NetTestHelper.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/qml/NetTestHelper.cpp
@@ -4,9 +4,9 @@
 
 extern "C" {
 
-void net_test_helper_runQml(QQmlApplicationEngineContainer* qmlEngineContainer, LPWSTR qml) {
+Q_DECL_EXPORT void net_test_helper_runQml(QQmlApplicationEngineContainer* qmlEngineContainer, LPWSTR qml) {
     QQmlComponent component(qmlEngineContainer->qmlEngine.data());
-    QString qmlString = QString::fromUtf16(qml);
+    QString qmlString = QString::fromUtf16((const char16_t*)qml);
     component.setData(qmlString.toUtf8(), QUrl());
     QObject *object = component.create();
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/qml/NetVariant.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/qml/NetVariant.cpp
@@ -196,7 +196,7 @@ void NetVariant::clearNetInstance()
 
 extern "C" {
 
-struct DateTimeContainer {
+struct Q_DECL_EXPORT DateTimeContainer {
     bool isNull;
     int month;
     int day;
@@ -208,21 +208,21 @@ struct DateTimeContainer {
     int offsetSeconds;
 };
 
-NetVariantContainer* net_variant_create() {
+Q_DECL_EXPORT NetVariantContainer* net_variant_create() {
     NetVariantContainer* result = new NetVariantContainer();
     result->variant = QSharedPointer<NetVariant>(new NetVariant());
     return result;
 }
 
-void net_variant_destroy(NetVariantContainer* container) {
+Q_DECL_EXPORT void net_variant_destroy(NetVariantContainer* container) {
     delete container;
 }
 
-NetVariantTypeEnum net_variant_getVariantType(NetVariantContainer* container) {
+Q_DECL_EXPORT NetVariantTypeEnum net_variant_getVariantType(NetVariantContainer* container) {
     return container->variant->getVariantType();
 }
 
-void net_variant_setNetInstance(NetVariantContainer* container, NetInstanceContainer* instanceContainer) {
+Q_DECL_EXPORT void net_variant_setNetInstance(NetVariantContainer* container, NetInstanceContainer* instanceContainer) {
     if(instanceContainer == NULL) {
         container->variant->setNetInstance(NULL);
     } else {
@@ -230,7 +230,7 @@ void net_variant_setNetInstance(NetVariantContainer* container, NetInstanceConta
     }
 }
 
-NetInstanceContainer* net_variant_getNetInstance(NetVariantContainer* container) {
+Q_DECL_EXPORT NetInstanceContainer* net_variant_getNetInstance(NetVariantContainer* container) {
     QSharedPointer<NetInstance> instance = container->variant->getNetInstance();
     if(instance == NULL) {
         return NULL;
@@ -240,56 +240,56 @@ NetInstanceContainer* net_variant_getNetInstance(NetVariantContainer* container)
     return result;
 }
 
-void net_variant_setBool(NetVariantContainer* container, bool value) {
+Q_DECL_EXPORT void net_variant_setBool(NetVariantContainer* container, bool value) {
     container->variant->setBool(value);
 }
 
-bool net_variant_getBool(NetVariantContainer* container) {
+Q_DECL_EXPORT bool net_variant_getBool(NetVariantContainer* container) {
     return container->variant->getBool();
 }
 
-void net_variant_setChar(NetVariantContainer* container, ushort value) {
+Q_DECL_EXPORT void net_variant_setChar(NetVariantContainer* container, ushort value) {
     container->variant->setChar(value);
 }
 
-ushort net_variant_getChar(NetVariantContainer* container) {
+Q_DECL_EXPORT ushort net_variant_getChar(NetVariantContainer* container) {
     return (ushort)container->variant->getChar().unicode();
 }
 
-void net_variant_setInt(NetVariantContainer* container, int value) {
+Q_DECL_EXPORT void net_variant_setInt(NetVariantContainer* container, int value) {
     container->variant->setInt(value);
 }
 
-int net_variant_getInt(NetVariantContainer* container) {
+Q_DECL_EXPORT int net_variant_getInt(NetVariantContainer* container) {
     return container->variant->getInt();
 }
 
-void net_variant_setUInt(NetVariantContainer* container, unsigned int value) {
+Q_DECL_EXPORT void net_variant_setUInt(NetVariantContainer* container, unsigned int value) {
     container->variant->setUInt(value);
 }
 
-unsigned int net_variant_getUInt(NetVariantContainer* container) {
+Q_DECL_EXPORT unsigned int net_variant_getUInt(NetVariantContainer* container) {
     return container->variant->getUInt();
 }
 
-void net_variant_setDouble(NetVariantContainer* container, double value) {
+Q_DECL_EXPORT void net_variant_setDouble(NetVariantContainer* container, double value) {
     container->variant->setDouble(value);
 }
 
-double net_variant_getDouble(NetVariantContainer* container) {
+Q_DECL_EXPORT double net_variant_getDouble(NetVariantContainer* container) {
     return container->variant->getDouble();
 }
 
-void net_variant_setString(NetVariantContainer* container, LPWSTR value) {
+Q_DECL_EXPORT void net_variant_setString(NetVariantContainer* container, LPWSTR value) {
     if(value == NULL) {
         container->variant->setString(NULL);
     } else {
-        QString temp = QString::fromUtf16(value);
+        QString temp = QString::fromUtf16((const char16_t*)value);
         container->variant->setString(&temp);
     }
 }
 
-LPWSTR net_variant_getString(NetVariantContainer* container) {
+Q_DECL_EXPORT LPWSTR net_variant_getString(NetVariantContainer* container) {
     QString string = container->variant->getString();
     if(string.isNull()) {
         return NULL;
@@ -297,7 +297,7 @@ LPWSTR net_variant_getString(NetVariantContainer* container) {
     return (LPWSTR)string.utf16();
 }
 
-void net_variant_setDateTime(NetVariantContainer* container, DateTimeContainer* value) {
+Q_DECL_EXPORT void net_variant_setDateTime(NetVariantContainer* container, DateTimeContainer* value) {
     if(value == NULL || value->isNull) {
         QDateTime dt;
         container->variant->setDateTime(dt);
@@ -308,7 +308,7 @@ void net_variant_setDateTime(NetVariantContainer* container, DateTimeContainer* 
         container->variant->setDateTime(dt);
     }
 }
-void net_variant_getDateTime(NetVariantContainer* container, DateTimeContainer* value) {
+Q_DECL_EXPORT void net_variant_getDateTime(NetVariantContainer* container, DateTimeContainer* value) {
     QDateTime dt = container->variant->getDateTime();
     if(dt.isNull()) {
         value->isNull = true;
@@ -329,7 +329,7 @@ void net_variant_getDateTime(NetVariantContainer* container, DateTimeContainer* 
     value->offsetSeconds = dt.offsetFromUtc();
 }
 
-void net_variant_clear(NetVariantContainer* container) {
+Q_DECL_EXPORT void net_variant_clear(NetVariantContainer* container) {
     container->variant->clear();
 }
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/qml/NetVariantList.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/qml/NetVariantList.cpp
@@ -34,25 +34,25 @@ void NetVariantList::clear() {
 
 extern "C" {
 
-NetVariantListContainer* net_variant_list_create() {
+Q_DECL_EXPORT NetVariantListContainer* net_variant_list_create() {
     NetVariantListContainer* result = new NetVariantListContainer();
     result->list = QSharedPointer<NetVariantList>(new NetVariantList());
     return result;
 }
 
-void net_variant_list_destroy(NetVariantListContainer* container) {
+Q_DECL_EXPORT void net_variant_list_destroy(NetVariantListContainer* container) {
     delete container;
 }
 
-int net_variant_list_count(NetVariantListContainer* container) {
+Q_DECL_EXPORT int net_variant_list_count(NetVariantListContainer* container) {
     return container->list->count();
 }
 
-void net_variant_list_add(NetVariantListContainer* container, NetVariantContainer* variant) {
+Q_DECL_EXPORT void net_variant_list_add(NetVariantListContainer* container, NetVariantContainer* variant) {
     container->list->add(variant->variant);
 }
 
-NetVariantContainer* net_variant_list_get(NetVariantListContainer* container, int index){
+Q_DECL_EXPORT NetVariantContainer* net_variant_list_get(NetVariantListContainer* container, int index){
     QSharedPointer<NetVariant> variant = container->list->get(index);
     if(variant == NULL) return NULL;
     NetVariantContainer* result = new NetVariantContainer();
@@ -60,11 +60,11 @@ NetVariantContainer* net_variant_list_get(NetVariantListContainer* container, in
     return result;
 }
 
-void net_variant_list_remove(NetVariantListContainer* container, int index) {
+Q_DECL_EXPORT void net_variant_list_remove(NetVariantListContainer* container, int index) {
     container->list->remove(index);
 }
 
-void net_variant_list_clear(NetVariantListContainer* container) {
+Q_DECL_EXPORT void net_variant_list_clear(NetVariantListContainer* container) {
     container->list->clear();
 }
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/qml/QGuiApplication.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/qml/QGuiApplication.cpp
@@ -1,5 +1,6 @@
 #include <QtNetCoreQml/qml/QGuiApplication.h>
 #include <QGuiApplication>
+#include <QtNetCoreQml.h>
 
 GuiThreadContextTriggerCallback::GuiThreadContextTriggerCallback() :
     callback(NULL) {
@@ -14,7 +15,7 @@ void GuiThreadContextTriggerCallback::trigger() {
 
 extern "C" {
 
-QGuiApplicationContainer* qguiapplication_create() {
+Q_DECL_EXPORT QGuiApplicationContainer* qguiapplication_create() {
     QGuiApplicationContainer* result = new QGuiApplicationContainer();
     result->argCount = 0;
     result->guiApp = QSharedPointer<QGuiApplication>(new QGuiApplication(result->argCount, (char**)NULL, 0));
@@ -22,19 +23,19 @@ QGuiApplicationContainer* qguiapplication_create() {
     return result;
 }
 
-void qguiapplication_destroy(QGuiApplicationContainer* container) {
+Q_DECL_EXPORT void qguiapplication_destroy(QGuiApplicationContainer* container) {
     delete container;
 }
 
-int qguiapplication_exec(QGuiApplicationContainer* container) {
+Q_DECL_EXPORT int qguiapplication_exec(QGuiApplicationContainer* container) {
     return container->guiApp->exec();
 }
 
-void qguiapplication_addTriggerCallback(QGuiApplicationContainer* container, guiThreadTriggerCb callback) {
+Q_DECL_EXPORT void qguiapplication_addTriggerCallback(QGuiApplicationContainer* container, guiThreadTriggerCb callback) {
     container->callback->callback = callback;
 }
 
-void qguiapplication_requestTrigger(QGuiApplicationContainer* container) {
+Q_DECL_EXPORT void qguiapplication_requestTrigger(QGuiApplicationContainer* container) {
     QMetaObject::invokeMethod(container->callback.data(), "trigger", Qt::QueuedConnection);
 }
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/qml/QQmlApplicationEngine.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/qml/QQmlApplicationEngine.cpp
@@ -2,40 +2,6 @@
 #include <QtNetCoreQml/types/NetTypeInfo.h>
 #include <QtNetCoreQml/qml/NetValueType.h>
 
-#define DEFINE_NETVALUETYPE(N) \
-    template<> QMetaObject NetValueType<N>::staticMetaObject = QMetaObject();
-
-DEFINE_NETVALUETYPE(1)
-DEFINE_NETVALUETYPE(2)
-DEFINE_NETVALUETYPE(3)
-DEFINE_NETVALUETYPE(4)
-DEFINE_NETVALUETYPE(5)
-DEFINE_NETVALUETYPE(6)
-DEFINE_NETVALUETYPE(7)
-DEFINE_NETVALUETYPE(8)
-DEFINE_NETVALUETYPE(9)
-DEFINE_NETVALUETYPE(10)
-DEFINE_NETVALUETYPE(11)
-DEFINE_NETVALUETYPE(12)
-DEFINE_NETVALUETYPE(13)
-DEFINE_NETVALUETYPE(14)
-DEFINE_NETVALUETYPE(15)
-DEFINE_NETVALUETYPE(16)
-DEFINE_NETVALUETYPE(17)
-DEFINE_NETVALUETYPE(18)
-DEFINE_NETVALUETYPE(19)
-DEFINE_NETVALUETYPE(20)
-DEFINE_NETVALUETYPE(21)
-DEFINE_NETVALUETYPE(22)
-DEFINE_NETVALUETYPE(23)
-DEFINE_NETVALUETYPE(24)
-DEFINE_NETVALUETYPE(25)
-DEFINE_NETVALUETYPE(26)
-DEFINE_NETVALUETYPE(27)
-DEFINE_NETVALUETYPE(28)
-DEFINE_NETVALUETYPE(29)
-DEFINE_NETVALUETYPE(30)
-
 static int netValueTypeNumber = 0;
 
 #define NETVALUETYPE_CASE(N) \
@@ -43,24 +9,24 @@ static int netValueTypeNumber = 0;
 
 extern "C" {
 
-QQmlApplicationEngineContainer* qqmlapplicationengine_create() {
+Q_DECL_EXPORT QQmlApplicationEngineContainer* qqmlapplicationengine_create() {
     QQmlApplicationEngineContainer* result = new QQmlApplicationEngineContainer();
     result->qmlEngine = QSharedPointer<QQmlApplicationEngine>(new QQmlApplicationEngine());
     return result;
 }
 
-void qqmlapplicationengine_destroy(QQmlApplicationEngineContainer* container) {
+Q_DECL_EXPORT void qqmlapplicationengine_destroy(QQmlApplicationEngineContainer* container) {
     delete container;
 }
 
-void qqmlapplicationengine_load(QQmlApplicationEngineContainer* container, LPWSTR path) {
-    container->qmlEngine->load(QString::fromUtf16(path));
+Q_DECL_EXPORT void qqmlapplicationengine_load(QQmlApplicationEngineContainer* container, LPWSTR path) {
+    container->qmlEngine->load(QString::fromUtf16((const char16_t*)path));
 }
 
-int qqmlapplicationengine_registerType(NetTypeInfoContainer* typeContainer, LPWSTR uri, int versionMajor, int versionMinor, LPWSTR qmlName) {
+Q_DECL_EXPORT int qqmlapplicationengine_registerType(NetTypeInfoContainer* typeContainer, LPWSTR uri, int versionMajor, int versionMinor, LPWSTR qmlName) {
 
-    QString uriString = QString::fromUtf16(uri);
-    QString qmlNameString = QString::fromUtf16(qmlName);
+    QString uriString = QString::fromUtf16((const char16_t*)uri);
+    QString qmlNameString = QString::fromUtf16((const char16_t*)qmlName);
     QSharedPointer<NetTypeInfo> typeInfo = typeContainer->netTypeInfo;
     QString fullType = typeInfo->getFullTypeName();
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/types/Callbacks.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/types/Callbacks.cpp
@@ -8,7 +8,7 @@ typedef void (*readPropertyCb)(NetPropertyInfoContainer* property, NetInstanceCo
 typedef void (*writePropertyCb)(NetPropertyInfoContainer* property, NetInstanceContainer* target, NetVariantContainer* value);
 typedef void (*invokeMethodCb)(NetMethodInfoContainer* method, NetInstanceContainer* target, NetVariantListContainer* parameters, NetVariantContainer* result);
 
-struct NetTypeInfoManagerCallbacks {
+struct Q_DECL_EXPORT NetTypeInfoManagerCallbacks {
     isTypeValidCb isTypeValid;
     buildTypeInfoCb buildTypeInfo;
     releaseGCHandleCb releaseGCHandle;
@@ -86,35 +86,35 @@ void invokeNetMethod(QSharedPointer<NetMethodInfo> method, QSharedPointer<NetIns
 
 extern "C" {
 
-void type_info_callbacks_registerCallbacks(NetTypeInfoManagerCallbacks* callbacks) {
+Q_DECL_EXPORT void type_info_callbacks_registerCallbacks(NetTypeInfoManagerCallbacks* callbacks) {
     sharedCallbacks = *callbacks;
 }
 
-bool type_info_callbacks_isTypeValid(LPWSTR typeName) {
+Q_DECL_EXPORT bool type_info_callbacks_isTypeValid(LPWSTR typeName) {
     return sharedCallbacks.isTypeValid(typeName);
 }
 
-void type_info_callbacks_releaseGCHandle(NetGCHandle* handle) {
+Q_DECL_EXPORT void type_info_callbacks_releaseGCHandle(NetGCHandle* handle) {
     sharedCallbacks.releaseGCHandle(handle);
 }
 
-void type_info_callbacks_buildTypeInfo(NetTypeInfoContainer* typeInfo) {
+Q_DECL_EXPORT void type_info_callbacks_buildTypeInfo(NetTypeInfoContainer* typeInfo) {
     sharedCallbacks.buildTypeInfo(typeInfo);
 }
 
-NetGCHandle* type_info_callbacks_instantiateType(LPWSTR typeName) {
+Q_DECL_EXPORT NetGCHandle* type_info_callbacks_instantiateType(LPWSTR typeName) {
     return sharedCallbacks.instantiateType(typeName);
 }
 
-void type_info_callbacks_readProperty(NetPropertyInfoContainer* property, NetInstanceContainer* target, NetVariantContainer* result) {
+Q_DECL_EXPORT void type_info_callbacks_readProperty(NetPropertyInfoContainer* property, NetInstanceContainer* target, NetVariantContainer* result) {
     sharedCallbacks.readProperty(property, target, result);
 }
 
-void type_info_callbacks_writeProperty(NetPropertyInfoContainer* property, NetInstanceContainer* target, NetVariantContainer* value) {
+Q_DECL_EXPORT void type_info_callbacks_writeProperty(NetPropertyInfoContainer* property, NetInstanceContainer* target, NetVariantContainer* value) {
     sharedCallbacks.writeProperty(property, target, value);
 }
 
-void type_info_callbacks_invokeMethod(NetMethodInfoContainer* method, NetInstanceContainer* target, NetVariantListContainer* parameters, NetVariantContainer* result) {
+Q_DECL_EXPORT void type_info_callbacks_invokeMethod(NetMethodInfoContainer* method, NetInstanceContainer* target, NetVariantListContainer* parameters, NetVariantContainer* result) {
     sharedCallbacks.invokeMethod(method, target, parameters, result);
 }
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/types/NetInstance.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/types/NetInstance.cpp
@@ -27,17 +27,17 @@ QSharedPointer<NetTypeInfo> NetInstance::getTypeInfo()
 
 extern "C" {
 
-NetInstanceContainer* net_instance_create(NetGCHandle* handle, NetTypeInfoContainer* typeContainer) {
+Q_DECL_EXPORT NetInstanceContainer* net_instance_create(NetGCHandle* handle, NetTypeInfoContainer* typeContainer) {
     NetInstanceContainer* result = new NetInstanceContainer();
     result->instance = QSharedPointer<NetInstance>(new NetInstance(handle, typeContainer->netTypeInfo));
     return result;
 }
 
-void net_instance_destroy(NetInstanceContainer* container) {
+Q_DECL_EXPORT void net_instance_destroy(NetInstanceContainer* container) {
     delete container;
 }
 
-NetGCHandle* net_instance_getHandle(NetInstanceContainer* container) {
+Q_DECL_EXPORT NetGCHandle* net_instance_getHandle(NetInstanceContainer* container) {
     return container->instance->getGCHandle();
 }
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/types/NetMethodInfo.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/types/NetMethodInfo.cpp
@@ -46,21 +46,21 @@ QSharedPointer<NetMethodInfoArguement> NetMethodInfo::getParameter(uint index) {
 
 extern "C" {
 
-void method_info_parameter_destroy(NetMethodInfoArguementContainer* container) {
+Q_DECL_EXPORT void method_info_parameter_destroy(NetMethodInfoArguementContainer* container) {
     delete container;
 }
 
-LPWSTR method_info_parameter_getName(NetMethodInfoArguementContainer* container) {
+Q_DECL_EXPORT LPWSTR method_info_parameter_getName(NetMethodInfoArguementContainer* container) {
     return (LPWSTR)container->methodArguement->getName().utf16();
 }
 
-NetTypeInfoContainer* method_info_parameter_getType(NetMethodInfoArguementContainer* container) {
+Q_DECL_EXPORT NetTypeInfoContainer* method_info_parameter_getType(NetMethodInfoArguementContainer* container) {
     NetTypeInfoContainer* result = new NetTypeInfoContainer();
     result->netTypeInfo = container->methodArguement->getType();
     return result;
 }
 
-NetMethodInfoContainer* method_info_create(NetTypeInfoContainer* parentTypeContainer, LPWSTR methodName, NetTypeInfoContainer* returnTypeContainer) {
+Q_DECL_EXPORT NetMethodInfoContainer* method_info_create(NetTypeInfoContainer* parentTypeContainer, LPWSTR methodName, NetTypeInfoContainer* returnTypeContainer) {
     NetMethodInfoContainer* result = new NetMethodInfoContainer();
 
     QSharedPointer<NetTypeInfo> parentType;
@@ -73,20 +73,20 @@ NetMethodInfoContainer* method_info_create(NetTypeInfoContainer* parentTypeConta
         returnType = returnTypeContainer->netTypeInfo;
     }
 
-    NetMethodInfo* instance = new NetMethodInfo(parentType, QString::fromUtf16(methodName), returnType);
+    NetMethodInfo* instance = new NetMethodInfo(parentType, QString::fromUtf16((const char16_t*)methodName), returnType);
     result->method = QSharedPointer<NetMethodInfo>(instance);
     return result;
 }
 
-void method_info_destroy(NetMethodInfoContainer* container) {
+Q_DECL_EXPORT void method_info_destroy(NetMethodInfoContainer* container) {
     delete container;
 }
 
-LPWSTR method_info_getMethodName(NetMethodInfoContainer* container) {
+Q_DECL_EXPORT LPWSTR method_info_getMethodName(NetMethodInfoContainer* container) {
     return (LPWSTR)container->method->getMethodName().utf16();
 }
 
-NetTypeInfoContainer* method_info_getReturnType(NetMethodInfoContainer* container) {
+Q_DECL_EXPORT NetTypeInfoContainer* method_info_getReturnType(NetMethodInfoContainer* container) {
     QSharedPointer<NetTypeInfo> returnType = container->method->getReturnType();
     if(returnType == NULL) {
         return NULL;
@@ -96,15 +96,15 @@ NetTypeInfoContainer* method_info_getReturnType(NetMethodInfoContainer* containe
     return result;
 }
 
-void method_info_addParameter(NetMethodInfoContainer* container, LPWSTR name, NetTypeInfoContainer* typeInfoContainer) {
-    container->method->addParameter(QString::fromUtf16(name), typeInfoContainer->netTypeInfo);
+Q_DECL_EXPORT void method_info_addParameter(NetMethodInfoContainer* container, LPWSTR name, NetTypeInfoContainer* typeInfoContainer) {
+    container->method->addParameter(QString::fromUtf16((const char16_t*)name), typeInfoContainer->netTypeInfo);
 }
 
-uint method_info_getParameterCount(NetMethodInfoContainer* container) {
+Q_DECL_EXPORT uint method_info_getParameterCount(NetMethodInfoContainer* container) {
     return container->method->getParameterCount();
 }
 
-NetMethodInfoArguementContainer* method_info_getParameter(NetMethodInfoContainer* container, uint index) {
+Q_DECL_EXPORT NetMethodInfoArguementContainer* method_info_getParameter(NetMethodInfoContainer* container, uint index) {
     QSharedPointer<NetMethodInfoArguement> parameter = container->method->getParameter(index);
     if(parameter == NULL) {
         return NULL;

--- a/src/native/QtNetCoreQml/QtNetCoreQml/types/NetPropertyInfo.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/types/NetPropertyInfo.cpp
@@ -41,14 +41,14 @@ bool NetPropertyInfo::canWrite()
 
 extern "C" {
 
-NetPropertyInfoContainer* property_info_create(NetTypeInfoContainer* parentType,
+Q_DECL_EXPORT NetPropertyInfoContainer* property_info_create(NetTypeInfoContainer* parentType,
                                                LPWSTR name,
                                                NetTypeInfoContainer* returnType,
                                                bool canRead,
                                                bool canWrite) {
     NetPropertyInfoContainer* result = new NetPropertyInfoContainer();
     NetPropertyInfo* instance = new NetPropertyInfo(parentType->netTypeInfo,
-                                                    QString::fromUtf16(name),
+                                                    QString::fromUtf16((const char16_t*)name),
                                                     returnType->netTypeInfo,
                                                     canRead,
                                                     canWrite);
@@ -56,32 +56,32 @@ NetPropertyInfoContainer* property_info_create(NetTypeInfoContainer* parentType,
     return result;
 }
 
-void property_info_destroy(NetTypeInfoContainer* container) {
+Q_DECL_EXPORT void property_info_destroy(NetTypeInfoContainer* container) {
     delete container;
 }
 
-NetTypeInfoContainer* property_info_getParentType(NetPropertyInfoContainer* container) {
+Q_DECL_EXPORT NetTypeInfoContainer* property_info_getParentType(NetPropertyInfoContainer* container) {
     NetTypeInfoContainer* result = new NetTypeInfoContainer();
     result->netTypeInfo = container->property->getParentType();
     return result;
 }
 
 
-LPWSTR property_info_getPropertyName(NetPropertyInfoContainer* container) {
+Q_DECL_EXPORT LPWSTR property_info_getPropertyName(NetPropertyInfoContainer* container) {
     return (LPWSTR)container->property->getPropertyName().utf16();
 }
 
-NetTypeInfoContainer* property_info_getReturnType(NetPropertyInfoContainer* container) {
+Q_DECL_EXPORT NetTypeInfoContainer* property_info_getReturnType(NetPropertyInfoContainer* container) {
     NetTypeInfoContainer* result = new NetTypeInfoContainer();
     result->netTypeInfo = container->property->getReturnType();
     return result;
 }
 
-bool property_info_canRead(NetPropertyInfoContainer* container) {
+Q_DECL_EXPORT bool property_info_canRead(NetPropertyInfoContainer* container) {
     return container->property->canRead();
 }
 
-bool property_info_canWrite(NetPropertyInfoContainer* container) {
+Q_DECL_EXPORT bool property_info_canWrite(NetPropertyInfoContainer* container) {
     return container->property->canWrite();
 }
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/types/NetTypeInfo.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/types/NetTypeInfo.cpp
@@ -62,46 +62,46 @@ QSharedPointer<NetPropertyInfo> NetTypeInfo::getProperty(uint index) {
 
 extern "C" {
 
-NetTypeInfoContainer* type_info_create(LPWSTR fullTypeName) {
+Q_DECL_EXPORT NetTypeInfoContainer* type_info_create(LPWSTR fullTypeName) {
     NetTypeInfoContainer* result = new NetTypeInfoContainer();
-    result->netTypeInfo = QSharedPointer<NetTypeInfo>(new NetTypeInfo(QString::fromUtf16(fullTypeName)));
+    result->netTypeInfo = QSharedPointer<NetTypeInfo>(new NetTypeInfo(QString::fromUtf16((const char16_t*)fullTypeName)));
     return result;
 }
 
-void type_info_destroy(NetTypeInfoContainer* netTypeInfo) {
+Q_DECL_EXPORT void type_info_destroy(NetTypeInfoContainer* netTypeInfo) {
     delete netTypeInfo;
     netTypeInfo = NULL;
 }
 
-LPWSTR type_info_getFullTypeName(NetTypeInfoContainer* netTypeInfo) {
+Q_DECL_EXPORT LPWSTR type_info_getFullTypeName(NetTypeInfoContainer* netTypeInfo) {
     return (LPWSTR)netTypeInfo->netTypeInfo->getFullTypeName().utf16();
 }
 
-LPWSTR type_info_getClassName(NetTypeInfoContainer* netTypeInfo) {
+Q_DECL_EXPORT LPWSTR type_info_getClassName(NetTypeInfoContainer* netTypeInfo) {
     return (LPWSTR)netTypeInfo->netTypeInfo->getClassName().utf16();
 }
 
-void type_info_setClassName(NetTypeInfoContainer* netTypeInfo, LPWSTR className) {
-    netTypeInfo->netTypeInfo->setClassName(QString::fromUtf16(className));
+Q_DECL_EXPORT void type_info_setClassName(NetTypeInfoContainer* netTypeInfo, LPWSTR className) {
+    netTypeInfo->netTypeInfo->setClassName(QString::fromUtf16((const char16_t*)className));
 }
 
-NetVariantTypeEnum type_info_getPrefVariantType(NetTypeInfoContainer* netTypeInfo) {
+Q_DECL_EXPORT NetVariantTypeEnum type_info_getPrefVariantType(NetTypeInfoContainer* netTypeInfo) {
     return netTypeInfo->netTypeInfo->getPrefVariantType();
 }
 
-void type_info_setPrefVariantType(NetTypeInfoContainer* netTypeInfo, NetVariantTypeEnum variantType) {
+Q_DECL_EXPORT void type_info_setPrefVariantType(NetTypeInfoContainer* netTypeInfo, NetVariantTypeEnum variantType) {
     netTypeInfo->netTypeInfo->setPrefVariantType(variantType);
 }
 
-void type_info_addMethod(NetTypeInfoContainer* netTypeInfo, NetMethodInfoContainer* methodInfo) {
+Q_DECL_EXPORT void type_info_addMethod(NetTypeInfoContainer* netTypeInfo, NetMethodInfoContainer* methodInfo) {
     netTypeInfo->netTypeInfo->addMethod(methodInfo->method);
 }
 
-uint type_info_getMethodCount(NetTypeInfoContainer* container) {
+Q_DECL_EXPORT uint type_info_getMethodCount(NetTypeInfoContainer* container) {
     return container->netTypeInfo->getMethodCount();
 }
 
-NetMethodInfoContainer* type_info_getMethodInfo(NetTypeInfoContainer* container, uint index) {
+Q_DECL_EXPORT NetMethodInfoContainer* type_info_getMethodInfo(NetTypeInfoContainer* container, uint index) {
     QSharedPointer<NetMethodInfo> methodInfo = container->netTypeInfo->getMethodInfo(index);
     if(methodInfo == NULL) {
         return NULL;
@@ -111,15 +111,15 @@ NetMethodInfoContainer* type_info_getMethodInfo(NetTypeInfoContainer* container,
     return result;
 }
 
-void type_info_addProperty(NetTypeInfoContainer* container, NetPropertyInfoContainer* propertyContainer) {
+Q_DECL_EXPORT void type_info_addProperty(NetTypeInfoContainer* container, NetPropertyInfoContainer* propertyContainer) {
     container->netTypeInfo->addProperty(propertyContainer->property);
 }
 
-uint type_info_getPropertyCount(NetTypeInfoContainer* container) {
+Q_DECL_EXPORT uint type_info_getPropertyCount(NetTypeInfoContainer* container) {
     return container->netTypeInfo->getPropertyCount();
 }
 
-NetPropertyInfoContainer* type_info_getProperty(NetTypeInfoContainer* container, uint index) {
+Q_DECL_EXPORT NetPropertyInfoContainer* type_info_getProperty(NetTypeInfoContainer* container, uint index) {
     QSharedPointer<NetPropertyInfo> property = container->netTypeInfo->getProperty(index);
     if(property == NULL) {
         return NULL;

--- a/src/native/QtNetCoreQml/QtNetCoreQml/types/NetTypeInfo.h
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/types/NetTypeInfo.h
@@ -40,7 +40,7 @@ private:
     QList<QSharedPointer<NetPropertyInfo>> _properties;
 };
 
-struct NetTypeInfoContainer {
+struct Q_DECL_EXPORT NetTypeInfoContainer {
     QSharedPointer<NetTypeInfo> netTypeInfo;
 };
 

--- a/src/native/QtNetCoreQml/QtNetCoreQml/types/NetTypeManager.cpp
+++ b/src/native/QtNetCoreQml/QtNetCoreQml/types/NetTypeManager.cpp
@@ -26,8 +26,8 @@ QSharedPointer<NetTypeInfo> NetTypeManager::getTypeInfo(QString typeName) {
 
 extern "C" {
 
-NetTypeInfoContainer* type_manager_getTypeInfo(LPWSTR fullTypeName) {
-    QSharedPointer<NetTypeInfo> typeInfo = NetTypeManager::getTypeInfo(QString::fromUtf16(fullTypeName));
+Q_DECL_EXPORT NetTypeInfoContainer* type_manager_getTypeInfo(LPWSTR fullTypeName) {
+    QSharedPointer<NetTypeInfo> typeInfo = NetTypeManager::getTypeInfo(QString::fromUtf16((const char16_t*)fullTypeName));
     if(typeInfo == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Q_DECL_EXPORT for all entry points for the native library
removed not needed static definition (DEFINE_NETVALUETYPE), this part is already declared and defined in the header