### PR TITLE
Added support for "Net.gcCollect()" in Qml.

### DIFF
--- a/src/native/QmlNet/QmlNet.pro
+++ b/src/native/QmlNet/QmlNet.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += gui qml core-private
+QT       += gui qml qml-private core-private
 
 CONFIG += c++11
 CONFIG += plugin

--- a/src/native/QmlNet/QmlNet/qml/QQmlApplicationEngine.h
+++ b/src/native/QmlNet/QmlNet/qml/QQmlApplicationEngine.h
@@ -4,9 +4,37 @@
 #include <QmlNet.h>
 #include <QQmlApplicationEngine>
 #include <QSharedPointer>
+#include <private/qqmlglobal_p.h>
+#include <private/qv4functionobject_p.h>
+#include <private/qjsengine_p.h>
+#include <private/qqmlengine_p.h>
 
 struct QQmlApplicationEngineContainer {
     QSharedPointer<QQmlApplicationEngine> qmlEngine;
 };
+
+class QQmlEngine;
+
+namespace QV4 {
+
+namespace Heap {
+
+struct NetObject : Object {
+    void init();
+};
+
+}
+
+struct NetObject : Object
+{
+    V4_OBJECT2(NetObject, Object)
+    #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+    static void method_gccollect(const BuiltinFunction *, Scope &scope, CallData *callData);
+    #else
+    static ReturnedValue method_gccollect(const FunctionObject *b, const Value *thisObject, const Value *argv, int argc);
+    #endif
+};
+
+}
 
 #endif // NET_QQMLAPPLICATIONENGINE_H

--- a/src/native/QmlNet/QmlNet/types/Callbacks.cpp
+++ b/src/native/QmlNet/QmlNet/types/Callbacks.cpp
@@ -7,6 +7,7 @@ typedef NetInstanceContainer* (*instantiateTypeCb)(NetTypeInfoContainer* type);
 typedef void (*readPropertyCb)(NetPropertyInfoContainer* property, NetInstanceContainer* target, NetVariantContainer* result);
 typedef void (*writePropertyCb)(NetPropertyInfoContainer* property, NetInstanceContainer* target, NetVariantContainer* value);
 typedef void (*invokeMethodCb)(NetMethodInfoContainer* method, NetInstanceContainer* target, NetVariantListContainer* parameters, NetVariantContainer* result);
+typedef void (*gcCollectCb)(int maxGeneration);
 
 struct Q_DECL_EXPORT NetTypeInfoManagerCallbacks {
     isTypeValidCb isTypeValid;
@@ -16,6 +17,7 @@ struct Q_DECL_EXPORT NetTypeInfoManagerCallbacks {
     readPropertyCb readProperty;
     writePropertyCb writeProperty;
     invokeMethodCb invokeMethod;
+    gcCollectCb gcCollect;
 };
 
 static NetTypeInfoManagerCallbacks sharedCallbacks;
@@ -91,6 +93,10 @@ void invokeNetMethod(QSharedPointer<NetMethodInfo> method, QSharedPointer<NetIns
     }
     sharedCallbacks.invokeMethod(methodContainer, targetContainer, parametersContainer, resultContainer);
     // The callbacks dispose of types.
+}
+
+void gcCollect(int maxGeneration) {
+    sharedCallbacks.gcCollect(maxGeneration);
 }
 
 extern "C" {

--- a/src/native/QmlNet/QmlNet/types/Callbacks.h
+++ b/src/native/QmlNet/QmlNet/types/Callbacks.h
@@ -25,4 +25,6 @@ void writeProperty(QSharedPointer<NetPropertyInfo> property, QSharedPointer<NetI
 
 void invokeNetMethod(QSharedPointer<NetMethodInfo> method, QSharedPointer<NetInstance> target, QSharedPointer<NetVariantList> parameters, QSharedPointer<NetVariant> result);
 
+void gcCollect(int generation);
+
 #endif // NET_TYPE_INFO_MANAGER_H

--- a/src/net/Qml.Net.Sandbox/Program.UI.cs
+++ b/src/net/Qml.Net.Sandbox/Program.UI.cs
@@ -11,84 +11,11 @@ namespace Qml.Net.Sandbox
         [Signal("testSignal", NetVariantType.String)]
         public class TestQmlImport
         {
-            readonly AnotherType _anotherType = new AnotherType();
-            
-            public AnotherType GetSharedInstance()
-            {
-                return _anotherType;
-            }
-        }
-
-        [Signal("testSignal", NetVariantType.String)]
-        public class AnotherType
-        {
             
         }
 
-        public class InstanceType
-        {
-            public InstanceType()
-            {
-
-            }
-
-            public void Log(string logMessage)
-            {
-                Console.WriteLine(logMessage);
-            }
-        }
-
-        public class TestQmlInstanceHandling
-        {
-            private InstanceType _instanceType;
-            private WeakReference<InstanceType> _weakInstanceTypeRef;
-
-            public int State { get; set; } = 0;
-
-            public TestQmlInstanceHandling()
-            {
-                _instanceType = new InstanceType();
-                _weakInstanceTypeRef = new WeakReference<InstanceType>(_instanceType);
-            }
-
-            public InstanceType GetInstance()
-            {
-                return _instanceType;
-            }
-
-            public void DeleteInstance()
-            {
-                _instanceType = null;
-            }
-
-            public void CreateNewInstance()
-            {
-                _instanceType = new InstanceType();
-                _weakInstanceTypeRef = new WeakReference<InstanceType>(_instanceType);
-            }
-
-            public bool IsInstanceAlive()
-            {
-                return _weakInstanceTypeRef.TryGetTarget(out var _);
-            }
-
-            public void GarbageCollect()
-            {
-                Thread.Sleep(1000);
-                GC.Collect(GC.MaxGeneration);
-            }
-        }
-        
         static int Main()
         {
-            Task.Factory.StartNew(() =>
-            {
-                while (true)
-                {
-                    Thread.Sleep(1000);
-                    GC.Collect(GC.MaxGeneration);
-                }
-            });
             using (var app = new QGuiApplication())
             {
                 using (var engine = new QQmlApplicationEngine())
@@ -96,7 +23,6 @@ namespace Qml.Net.Sandbox
                     engine.AddImportPath(Path.Combine(Directory.GetCurrentDirectory(), "Qml"));
                     
                     QQmlApplicationEngine.RegisterType<TestQmlImport>("test");
-                    QQmlApplicationEngine.RegisterType<TestQmlInstanceHandling>("testInstances");
 
                     engine.Load("main.qml");
 

--- a/src/net/Qml.Net.Sandbox/main.qml
+++ b/src/net/Qml.Net.Sandbox/main.qml
@@ -2,7 +2,6 @@ import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.0
 import test 1.0
-import testInstances 1.0
 
 ApplicationWindow {
     visible: true
@@ -11,129 +10,9 @@ ApplicationWindow {
     title: qsTr("Hello World")
 	Item {
 		Timer {
-			id: signalTimer
 			interval: 1000; running: true; repeat: true
 			onTriggered: {
-                var o = test.GetSharedInstance()
-                o.testSignal.connect(function(message) {
-                    console.log("Signal was raised: " + message)
-					signalTimer.running = false
-                })
-                var o2 = test.GetSharedInstance()
-                o2.testSignal("Hello")
-			}
-		}
-		Timer {
-		    id: instanceCheckTimer
-			property var instanceRef: null
-			interval: 1000; running: true; repeat: true
-			onTriggered: {
-				testInstances.GarbageCollect()
-				gc()
-				switch(testInstances.State) {
-					case 0:
-						console.log("Creating two QML references")
-						var ref1 = testInstances.GetInstance()
-						var ref2 = testInstances.GetInstance()
-
-						ref1 = null
-						ref2 = null
-					
-						console.log("Created and deleted two references on QML side. IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.State++
-						break
-					case 1:
-						testInstances.DeleteInstance()
-						console.log("Deleting .Net references. IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.State++
-						break
-					case 2:
-						if(!testInstances.IsInstanceAlive()) {
-							console.log("Yeah! Instance has been released!");
-							testInstances.State++
-						}
-						break
-					case 3:
-						testInstances.CreateNewInstance()
-						console.log("Created new .Net Instance. IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.State++
-						break
-					case 4:
-						instanceRef = testInstances.GetInstance()
-						var secondLocalRef = testInstances.GetInstance()
-
-						console.log("Created two QML refs. One scoped and one long living. IsAlive = " + testInstances.IsInstanceAlive())
-
-						testInstances.State++
-						//secondLocalRef will be freed here
-						break
-					case 5:
-						instanceRef.Log("Long living QML ref still works!")
-						testInstances.State++
-						break
-					case 6:
-						instanceRef.Log("Long living QML ref still works!")
-						testInstances.State++
-						break;
-					case 7:
-						console.log("Deleting long living QML ref. IsAlive = " + testInstances.IsInstanceAlive())
-						instanceRef = null
-						testInstances.State++
-						break;
-					case 8:
-						console.assert(testInstances.IsInstanceAlive(), ".Net object IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.State++
-						break;
-					case 9:
-						console.assert(testInstances.IsInstanceAlive(), ".Net object IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.State++
-						break;
-					case 10:
-						console.log("Releasing .Net instance a second time. IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.DeleteInstance()
-						testInstances.State++
-						break;
-					case 11:
-						if(!testInstances.IsInstanceAlive()) {
-							console.log("Yeah! Instance has been released a second time!");
-							testInstances.State++
-						}
-						break;
-					case 12:
-						testInstances.CreateNewInstance()
-						console.log("Created new .Net Instance. IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.State++
-						break
-					case 13:
-						instanceRef = testInstances.GetInstance()
-						testInstances.DeleteInstance()
-						console.log("a QML ref and deleted the .Net ref. IsAlive = " + testInstances.IsInstanceAlive())
-
-						testInstances.State++
-						break
-					case 14:
-						console.assert(testInstances.IsInstanceAlive(), ".Net object IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.State++
-						break;
-					case 15:
-						console.assert(testInstances.IsInstanceAlive(), ".Net object IsAlive = " + testInstances.IsInstanceAlive())
-						testInstances.State++
-						break;
-					case 16:
-						console.log("Releasing last QML ref. IsAlive = " + testInstances.IsInstanceAlive())
-						instanceRef = null
-						testInstances.State++
-						break;
-					case 17:
-						if(!testInstances.IsInstanceAlive()) {
-							console.log("Yeah! Instance has been released a third time!");
-							testInstances.State++
-						}
-						break;
-					default:
-						instanceCheckTimer.running = false
-						break;
-				}
+                Net.gcCollect(2)
 			}
 		}
 	}
@@ -144,9 +23,5 @@ ApplicationWindow {
 
 	TestQmlImport {
 		id: test
-	}
-
-	TestQmlInstanceHandling {
-		id: testInstances
 	}
 }

--- a/src/net/Qml.Net.Tests/Qml/LifetimeTests.cs
+++ b/src/net/Qml.Net.Tests/Qml/LifetimeTests.cs
@@ -46,11 +46,6 @@ namespace Qml.Net.Tests.Qml
                 return _parameterWeakRef.TryGetTarget(out SecondLevelType _);
             }
 
-            public void GarbageCollect()
-            {
-                GC.Collect(GC.MaxGeneration);
-            }
-
             public bool TestResult { get; set; }
         }
 
@@ -228,7 +223,7 @@ namespace Qml.Net.Tests.Qml
                                 test.ReleaseNetReferenceParameter()
                             
                                 gc()
-                                test.GarbageCollect()
+                                Net.gcCollect(2)
 
                                 checkAndQuitTimer.running = true
                             }
@@ -271,7 +266,7 @@ namespace Qml.Net.Tests.Qml
                                 var instance1 = test.Parameter
 
                                 test.ReleaseNetReferenceParameter()
-                                test.GarbageCollect()
+                                Net.gcCollect(2)
 
                                 checkAndQuitTimer.running = true
                             }
@@ -320,7 +315,7 @@ namespace Qml.Net.Tests.Qml
                                 //release second QML ref
                                 instance2 = null
                                 gc()
-                                test.GarbageCollect()
+                                Net.gcCollect(2)
 
                                 checkAndQuitTimer.running = true
                             }

--- a/src/net/Qml.Net/Internal/DefaultCallbacks.cs
+++ b/src/net/Qml.Net/Internal/DefaultCallbacks.cs
@@ -235,5 +235,10 @@ namespace Qml.Net.Internal
                 }
             }
         }
+
+        public void GCCollect(int maxGeneration)
+        {
+            GC.Collect(maxGeneration);
+        }
     }
 }


### PR DESCRIPTION
This also opens the doors to many other interactions with .NET from Qml. For example, a ```Net.create("full type name", ctrArg1, ctrArg2)```, etc.