### PR TITLE
AutoGenerated signals don't conflict with MVVM behavior

### DIFF
--- a/src/net/Qml.Net.Tests/Qml/AutoSignalTests.cs
+++ b/src/net/Qml.Net.Tests/Qml/AutoSignalTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Qml.Net.Tests.Qml
+{
+    public class SomeTestClass
+    {
+        public string PropertyWithoutSignal { get; set; }
+
+        [NotifySignal] public string PropertyWithNotifySignal { get; set; }
+
+        [NotifySignal("myCustomNotifySignal")] public string PropertyWithCustomNotifySignal { get; set; }
+
+        public void TriggerDefaultSignal()
+        {
+            this.ActivateSignal("dynamic__PropertyWithoutSignalChanged");
+        }
+
+        public bool DefaultSignalReceived { get; set; } = false;
+
+        public void TriggerNotifySignal()
+        {
+            this.ActivateNotifySignal(nameof(PropertyWithNotifySignal));
+        }
+
+        public bool NotifySignalReceived { get; set; } = false;
+
+        public void TriggerCustomNotifySignal()
+        {
+            this.ActivateNotifySignal(nameof(PropertyWithCustomNotifySignal));
+        }
+
+        public bool CustomNotifySignalReceived { get; set; } = false;
+    }
+
+    public class AutoSignalTests : BaseQmlTestsWithInstance<SomeTestClass>
+    {
+        public AutoSignalTests()
+            : base(true)
+        {
+        }
+
+        [Fact]
+        public void Does_register_autoSignals()
+        {
+            RunQmlTest(
+                "testClass",
+                @"
+                testClass.dynamic__PropertyWithoutSignalChanged.connect(function() {
+                    testClass.defaultSignalReceived = true;
+                })
+                testClass.propertyWithNotifySignalChanged.connect(function() {
+                    testClass.notifySignalReceived = true;
+                })
+                testClass.myCustomNotifySignal.connect(function() {
+                    testClass.customNotifySignalReceived = true;
+                })
+                testClass.triggerDefaultSignal();
+                testClass.triggerNotifySignal();
+                testClass.triggerCustomNotifySignal();
+            ");
+
+            Instance.DefaultSignalReceived.Should().Be(true);
+            Instance.NotifySignalReceived.Should().Be(true);
+            Instance.CustomNotifySignalReceived.Should().Be(true);
+        }
+    }
+}

--- a/src/net/Qml.Net.Tests/Qml/BaseQmlTests.cs
+++ b/src/net/Qml.Net.Tests/Qml/BaseQmlTests.cs
@@ -76,8 +76,9 @@ namespace Qml.Net.Tests.Qml
     {
         protected readonly Mock<T> Mock;
 
-        protected BaseQmlTests()
+        protected BaseQmlTests(bool enableAutoSignals = false)
         {
+            QmlNetConfig.AutoGenerateNotifySignals = enableAutoSignals;
             RegisterType<T>();
             Mock = new Mock<T>();
             TypeCreator.SetInstance(typeof(T), Mock.Object);
@@ -89,8 +90,9 @@ namespace Qml.Net.Tests.Qml
     {
         protected readonly T Instance;
 
-        protected BaseQmlTestsWithInstance()
+        protected BaseQmlTestsWithInstance(bool enableAutoSignals = false)
         {
+            QmlNetConfig.AutoGenerateNotifySignals = enableAutoSignals;
             RegisterType<T>();
             Instance = new T();
             TypeCreator.SetInstance(typeof(T), Instance);
@@ -104,8 +106,8 @@ namespace Qml.Net.Tests.Qml
 
         protected BaseQmlMvvmTestsWithInstance(bool autogenerateSignals = false)
         {
-            QmlNetConfig.AutoGenerateNotifySignals = autogenerateSignals;
             InteropBehaviors.ClearQmlInteropBehaviors();
+            QmlNetConfig.AutoGenerateNotifySignals = autogenerateSignals;
             InteropBehaviors.RegisterQmlInteropBehavior(new MvvmQmlInteropBehavior());
 
             RegisterType<T>();

--- a/src/net/Qml.Net.Tests/Qml/BaseQmlTests.cs
+++ b/src/net/Qml.Net.Tests/Qml/BaseQmlTests.cs
@@ -102,8 +102,9 @@ namespace Qml.Net.Tests.Qml
     {
         protected readonly T Instance;
 
-        protected BaseQmlMvvmTestsWithInstance()
+        protected BaseQmlMvvmTestsWithInstance(bool autogenerateSignals = false)
         {
+            QmlNetConfig.AutoGenerateNotifySignals = autogenerateSignals;
             InteropBehaviors.ClearQmlInteropBehaviors();
             InteropBehaviors.RegisterQmlInteropBehavior(new MvvmQmlInteropBehavior());
 

--- a/src/net/Qml.Net.Tests/Qml/MvvmInteropBehaviorTests.cs
+++ b/src/net/Qml.Net.Tests/Qml/MvvmInteropBehaviorTests.cs
@@ -270,4 +270,28 @@ namespace Qml.Net.Tests.Qml
             Instance.TestResult.Should().Be(true);
         }
     }
+
+    public class MvvmInteropBehaviorWithAutoGenerateSignalsTests : BaseQmlMvvmTestsWithInstance<ViewModelContainer>
+    {
+        public MvvmInteropBehaviorWithAutoGenerateSignalsTests()
+            : base(true)
+        {
+        }
+
+        [Fact]
+        public void Does_register_property_changed_signal_when_auto_signals_are_active()
+        {
+            RunQmlTest(
+                "viewModelContainer",
+                @"
+                    var vm = viewModelContainer.viewModel
+                    vm.stringPropertyChanged.connect(function() {
+                        viewModelContainer.testResult = true
+                    })
+                    viewModelContainer.changeStringPropertyTo('new value')
+                ");
+
+            Instance.TestResult.Should().Be(true);
+        }
+    }
 }

--- a/src/net/Qml.Net/Internal/Behaviors/AutoGenerateNotifySignalsBehavior.cs
+++ b/src/net/Qml.Net/Internal/Behaviors/AutoGenerateNotifySignalsBehavior.cs
@@ -1,0 +1,71 @@
+using System;
+using Qml.Net.Internal.Types;
+
+namespace Qml.Net.Internal.Behaviors
+{
+    // All properties have a default notify signal.
+    // This is so that when we read properties in QML,
+    // we don't get errors with "NON-NOTIFY PROPERTY BOUND
+    public class AutoGenerateNotifySignalsBehavior : IQmlInteropBehavior
+    {
+        public int Priority => 1000;
+
+        public bool IsApplicableFor(Type type)
+        {
+            return true;
+        }
+
+        void IQmlInteropBehavior.OnNetTypeInfoCreated(NetTypeInfo netTypeInfo, Type forType)
+        {
+            if (!IsApplicableFor(forType))
+            {
+                return;
+            }
+            for (var i = 0; i < netTypeInfo.PropertyCount; i++)
+            {
+                int? existingSignalIndex = null;
+
+                var property = netTypeInfo.GetProperty(i);
+                if (property.NotifySignal != null)
+                {
+                    // In this case some other behavior or the user has already set up a notify signal for this property.
+                    // We don't want to destroy that.
+                    continue;
+                }
+                var signalName = $"dynamic__{property.Name}Changed";
+
+                // Check if this signal already has been registered.
+                for (var signalIndex = 0; signalIndex < netTypeInfo.SignalCount; signalIndex++)
+                {
+                    var signal = netTypeInfo.GetSignal(signalIndex);
+                    if (string.Equals(signalName, signal.Name))
+                    {
+                        existingSignalIndex = signalIndex;
+                        break;
+                    }
+                }
+                if (existingSignalIndex.HasValue)
+                {
+                    // Signal for this property is already existent but not registered (we check that above).
+                    property.NotifySignal = netTypeInfo.GetSignal(existingSignalIndex.Value);
+                    continue;
+                }
+
+                // Create a new signal and link it to the property.
+                var notifySignalInfo = new NetSignalInfo(netTypeInfo, signalName);
+                netTypeInfo.AddSignal(notifySignalInfo);
+                property.NotifySignal = notifySignalInfo;
+            }
+        }
+
+        public void OnObjectEntersNative(object instance, ulong objectId)
+        {
+            // NOOP
+        }
+
+        public void OnObjectLeavesNative(object instance, ulong objectId)
+        {
+            // NOOP
+        }
+    }
+}

--- a/src/net/Qml.Net/Internal/Behaviors/MvvmQmlInteropBehavior.cs
+++ b/src/net/Qml.Net/Internal/Behaviors/MvvmQmlInteropBehavior.cs
@@ -42,6 +42,8 @@ namespace Qml.Net.Internal.Behaviors
 
         private static readonly Dictionary<Type, MvvmTypeInfo> TypeInfos = new Dictionary<Type, MvvmTypeInfo>();
 
+        public int Priority => 1;
+
         public bool IsApplicableFor(Type type)
         {
             return typeof(INotifyPropertyChanged).IsAssignableFrom(type);

--- a/src/net/Qml.Net/Internal/DefaultCallbacks.cs
+++ b/src/net/Qml.Net/Internal/DefaultCallbacks.cs
@@ -147,18 +147,6 @@ namespace Qml.Net.Internal
                     NetSignalInfo notifySignal = null;
                     var notifySignalAttribute = propertyInfo.GetCustomAttribute<NotifySignalAttribute>();
                     
-                    // All properties have a default notify signal.
-                    // This is so that when we read properties in QML,
-                    // we don't get errors with "NON-NOTIFY PROPERTY BOUND
-                    if (notifySignalAttribute == null && QmlNetConfig.AutoGenerateNotifySignals)
-                    {
-                        var dynamicName = $"dynamic__{propertyInfo.Name}Changed";
-                        notifySignalAttribute = new NotifySignalAttribute
-                        {
-                            Name = dynamicName
-                        };
-                    }
-                    
                     if (notifySignalAttribute != null)
                     {
                         var name = notifySignalAttribute.Name;

--- a/src/net/Qml.Net/Internal/IQmlInteropBehavior.cs
+++ b/src/net/Qml.Net/Internal/IQmlInteropBehavior.cs
@@ -5,6 +5,11 @@ namespace Qml.Net.Internal
 {
     internal interface IQmlInteropBehavior
     {
+        /// <summary>
+        /// Gets the priority of this behavior (lower is more prior)
+        /// </summary>
+        int Priority { get; }
+        
         bool IsApplicableFor(Type type);
 
         void OnNetTypeInfoCreated(NetTypeInfo netTypeInfo, Type forType);

--- a/src/net/Qml.Net/Internal/InteropBehaviors.cs
+++ b/src/net/Qml.Net/Internal/InteropBehaviors.cs
@@ -14,7 +14,8 @@ namespace Qml.Net.Internal
         private static IEnumerable<IQmlInteropBehavior> GetApplicableInteropBehaviors(Type forType)
         {
             return _QmlInteropBehaviors
-                        .Where(b => b.IsApplicableFor(forType));
+                        .Where(b => b.IsApplicableFor(forType))
+                        .OrderBy(b => b.Priority);
         }
 
         /// <summary>
@@ -31,6 +32,11 @@ namespace Qml.Net.Internal
             {
                 _QmlInteropBehaviors.Add(behavior);
             }
+        }
+
+        public static void RemoveQmlInteropBehavior<TBehavior>()
+        {
+            _QmlInteropBehaviors.RemoveAll(b => typeof(TBehavior).IsAssignableFrom(b.GetType()));
         }
 
         public static void ClearQmlInteropBehaviors()

--- a/src/net/Qml.Net/QmlNetConfig.cs
+++ b/src/net/Qml.Net/QmlNetConfig.cs
@@ -1,4 +1,6 @@
 using System;
+using Qml.Net.Internal;
+using Qml.Net.Internal.Behaviors;
 
 namespace Qml.Net
 {
@@ -18,8 +20,23 @@ namespace Qml.Net
 
         public static bool ShouldEnsureUIThread { get; set; } = true;
 
-        public static bool AutoGenerateNotifySignals { get; set; } = false;
-        
+        public static bool AutoGenerateNotifySignals
+        {
+            get => _autoGenerateNotifySignals;
+            set
+            {
+                _autoGenerateNotifySignals = value;
+                if (value)
+                {
+                    InteropBehaviors.RegisterQmlInteropBehavior(new AutoGenerateNotifySignalsBehavior());
+                }
+                else
+                {
+                    InteropBehaviors.RemoveQmlInteropBehavior<AutoGenerateNotifySignalsBehavior>();
+                }
+            }
+        }
+
         public static Action EnsureUIThreadDelegate = () =>
         {
             if (!QCoreApplication.IsMainThread)
@@ -32,6 +49,8 @@ Stack Trace:
                     "You must be on the UI thread to perform this task. See https://github.com/qmlnet/qmlnet/issues/112");
             }
         };
+
+        private static bool _autoGenerateNotifySignals = false;
 
         internal static void EnsureUIThread()
         {


### PR DESCRIPTION
This PR fixes the auto generation of signals interference with the MVVM behavior.

I changed that functionality to be a Behavior so that the order can be controlled.
This enables us to use the AutoGenerateNotifySignalsBehavior to act as a filler for properties that don't get signals at all.
By using this approach the MVVM relevant properties already have signals and don't get an autogenerated one.

This PR includes a unit test to reproduce the problem and a unit test for the feature itself.

I kept the config property though. Maybe we should switch to an Activate API like for the MVVM behavior?